### PR TITLE
Skip missing and allow selection of dep list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Usage:
 - `--dry` will only print the changes to happen, not write them to file
 - `--quiet` will only print the final statement
 - `--note` will add a `test-dependencies` field to the second file. Useful for tooling
+- `--skip-missing` will skip dependencies not present in the second file and only update what is present in both
+- `--from` which type of dependency list to sync from: "devDependencies" or "dependencies". Default: "dependencies"
+- `--to` which type of dependency list to sync to: "devDependencies" or "dependencies". Default: "dependencies"
 
 ```bash
 elm-deps-sync elm-package.json spec/elm/elm-package.json

--- a/bin/elm-deps-sync-cli.js
+++ b/bin/elm-deps-sync-cli.js
@@ -13,6 +13,9 @@ program
     .option('-d, --dry', 'Only print the changes to happen')
     .option('-q, --quiet', 'Will only print the final statement')
     .option('--note', 'Add a `test-dependencies` field to the second file')
+    .option('--from <from>', 'Which type of dependencies to sync from: "devDependencies" or "dependencies". Default: "dependencies"')
+    .option('--to <to>', 'Which type of dependencies to sync to: "devDependencies" or "dependencies". Default: "dependencies"')
+    .option('--skip-missing', 'Only change dependencies present in sub _and_ parent')
     .parse(process.argv);
 
 var files = program.args.slice(0, 2);
@@ -27,7 +30,7 @@ if (files.length === 0) {
 }
 
 if (files.length === 2) {
-    syncVersions(files[ 0 ], files[ 1 ], program.quiet, program.dry, program.note);
+    syncVersions(files[ 0 ], files[ 1 ], program.quiet, program.dry, program.note, program.skipMissing, program.from, program.to);
 } else {
     console.log(chalk.yellow('Please specify <parent> file and <sub> file to sync dependencies.'));
     process.exit(1);

--- a/tests/functionality.spec.js
+++ b/tests/functionality.spec.js
@@ -13,7 +13,7 @@ const TOP_PATH = path.resolve(TEST_DATA_FOLDER, PKG_FILENAME);
 const SPEC_PATH = path.resolve(TEST_DATA_FOLDER, SPEC_FOLDER, PKG_FILENAME);
 
 describe('Test dependency sync', function () {
-    before(function () {
+    beforeEach(function () {
 
         var packageSkeleton = {
             'version': '1.0.0',
@@ -24,6 +24,7 @@ describe('Test dependency sync', function () {
             'exposed-modules': [],
             'native-modules': true,
             'dependencies': {},
+            'devDependencies': {},
             'elm-version': '0.17.0 <= v <= 0.17.0'
         };
 
@@ -50,14 +51,14 @@ describe('Test dependency sync', function () {
         fs.writeFileSync(SPEC_PATH, JSON.stringify(specDepsPkg, null, 2));
     });
 
-    after(function () {
+    afterEach(function () {
 
         rimraf.sync(TEST_DATA_FOLDER);
     });
 
     it('Should have synced list of dependencies', function () {
 
-        syncVersions(TOP_PATH, SPEC_PATH, true);
+        syncVersions(TOP_PATH, SPEC_PATH, true, false, false, false, undefined, undefined);
 
         var specPkg = JSON.parse(fs.readFileSync(SPEC_PATH));
 
@@ -72,7 +73,7 @@ describe('Test dependency sync', function () {
 
     it('Should have a correct list of `test-dependencies` in spec elm-package.json', function () {
 
-        syncVersions(TOP_PATH, SPEC_PATH, true, false, true);
+        syncVersions(TOP_PATH, SPEC_PATH, true, false, true, false, undefined, undefined);
 
         var specPkg = JSON.parse(fs.readFileSync(SPEC_PATH));
 
@@ -80,6 +81,76 @@ describe('Test dependency sync', function () {
             'elm-community/spec-1': '1.0.0 <= v <= 1.0.0',
             'elm-community/spec-2': '1.0.0 <= v <= 1.0.0'
         });
+    });
+
+    it('Should only change versions for common dependencies with --skip-missing', function () {
+
+        syncVersions(TOP_PATH, SPEC_PATH, true, false, false, true, undefined, undefined);
+
+        var specPkg = JSON.parse(fs.readFileSync(SPEC_PATH));
+
+        expect(specPkg.dependencies).to.be.deep.equal({
+            'elm-community/top-1': '1.0.0 <= v <= 1.0.0',
+            'elm-community/top-2': '1.0.0 <= v <= 1.0.0',
+            'elm-community/spec-1': '1.0.0 <= v <= 1.0.0',
+            'elm-community/spec-2': '1.0.0 <= v <= 1.0.0'
+        });
+
+    });
+
+    it('Should sync from dependencies to devDependencies', function () {
+
+        syncVersions(TOP_PATH, SPEC_PATH, true, false, false, false, 'dependencies', 'devDependencies');
+
+        var specPkg = JSON.parse(fs.readFileSync(SPEC_PATH));
+
+        expect(specPkg['devDependencies']).to.be.deep.equal({
+            'elm-community/top-1': '1.0.0 <= v <= 1.0.0',
+            'elm-community/top-2': '1.0.0 <= v <= 1.0.0',
+            'elm-community/top-3': '1.0.0 <= v <= 1.0.0'
+        });
+
+    });
+
+    it('Should sync from devDependencies to dependencies', function () {
+        var topLevelPkg = {
+            'version': '1.0.0',
+            'summary': 'test elm deps sync',
+            'repository': 'https://github.com/NoRedInk/elm-ops-tooling',
+            'license': 'BSD-3',
+            'source-directories': '.',
+            'exposed-modules': [],
+            'native-modules': true,
+            'dependencies': {'elm-community/top-1': '1.0.0 <= v <= 1.0.0'},
+            'devDependencies': {'elm-community/from-dev-dep': '1.0.0 <= v <= 1.0.0'},
+            'elm-version': '0.17.0 <= v <= 0.17.0'
+        };
+
+        var specDepsPkg = {
+            'version': '1.0.0',
+            'summary': 'test elm deps sync',
+            'repository': 'https://github.com/NoRedInk/elm-ops-tooling',
+            'license': 'BSD-3',
+            'source-directories': '.',
+            'exposed-modules': [],
+            'native-modules': true,
+            'dependencies': {'elm-community/spec-1': '1.0.0 <= v <= 1.0.0'},
+            'devDependencies': {},
+            'elm-version': '0.17.0 <= v <= 0.17.0'
+        };
+
+        fs.writeFileSync(TOP_PATH, JSON.stringify(topLevelPkg, null, 2));
+        fs.writeFileSync(SPEC_PATH, JSON.stringify(specDepsPkg, null, 2));
+
+        syncVersions(TOP_PATH, SPEC_PATH, true, false, false, false, 'devDependencies', 'dependencies');
+
+        var specPkg = JSON.parse(fs.readFileSync(SPEC_PATH));
+
+        expect(specPkg['dependencies']).to.be.deep.equal({
+            'elm-community/spec-1': '1.0.0 <= v <= 1.0.0',
+            'elm-community/from-dev-dep': '1.0.0 <= v <= 1.0.0',
+        });
+
     });
 });
 


### PR DESCRIPTION
I was about to start writing my own script to do this but found this one doing mostly what we need. This PR adds in a few extras to help with situations where the sub-package.json is much smaller than the regular package.json.

We have a main package.json and another one for our end-to-end tests that is a small subset of the main package.json restricted to just `devDependencies`. To help with this I extended the tool with the following options:

```
- `--skip-missing` will skip dependencies not present in the second file and only update what is present in both
- `--from` which type of dependency list to sync from: "devDependencies" or "dependencies". Default: "dependencies"
- `--to` which type of dependency list to sync to: "devDependencies" or "dependencies". Default: "dependencies"
```

An example of usage:

```
$ elm-deps-sync package.json test/package.json --skip-missing --from dependencies --to  devDependencies
```

I also added some tests to exercise the new code. 